### PR TITLE
also check openWindow

### DIFF
--- a/tado-exporter/src/main/kotlin/click/dobel/tado/metrics/TadoMeterFactory.kt
+++ b/tado-exporter/src/main/kotlin/click/dobel/tado/metrics/TadoMeterFactory.kt
@@ -133,7 +133,8 @@ class TadoMeterFactory(
       zoneTags,
       zone
     ) { z ->
-      tadoApiClient.zoneState(home.id, z.id).isOpenWindowDetected == true
+      val state = tadoApiClient.zoneState(home.id, z.id)
+      state.isOpenWindowDetected == true || state.openWindow != null
     }
   }
 


### PR DESCRIPTION
openWindowDetected is not sent by the tado api even if the window is open (for me anyway).
Apparently it's only sent without a subscription [1].

[1] https://www.gitmemory.com/issue/home-assistant/home-assistant/30873/576190768