### PR TITLE
fix: stabilize zone model entries (e.g. on battery state changes)

### DIFF
--- a/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/apiclient/model/Zones.kt
+++ b/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/apiclient/model/Zones.kt
@@ -1,5 +1,8 @@
 package click.dobel.tado.exporter.apiclient.model
 
 import click.dobel.tado.api.Zone
+import click.dobel.tado.exporter.metrics.ZoneEntry
 
 class Zones(zones: Collection<Zone>) : List<Zone> by ArrayList(zones)
+
+fun Collection<Zone>.toEntrySet() = this.map(::ZoneEntry).toSet()

--- a/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/metrics/HomeModelRefresher.kt
+++ b/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/metrics/HomeModelRefresher.kt
@@ -44,9 +44,9 @@ class HomeModelRefresher(
       )
 
       val allZones = tadoApiClient.zones(userHomes.id)
-      val newZones = homeModel.updateHomeZones(userHomes, allZones)
+      val newZoneEntries = homeModel.updateHomeZones(userHomes, allZones)
 
-      tadoMeterFactory.createZoneMeters(userHomes, newZones)
+      tadoMeterFactory.createZoneMeters(userHomes, newZoneEntries)
     }
   }
 }

--- a/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/metrics/ZoneEntry.kt
+++ b/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/metrics/ZoneEntry.kt
@@ -1,0 +1,12 @@
+package click.dobel.tado.exporter.metrics
+
+import click.dobel.tado.api.TadoSystemType
+import click.dobel.tado.api.Zone
+
+data class ZoneEntry(
+  val id: Int,
+  val name: String,
+  val type: TadoSystemType
+) {
+  constructor(zone: Zone) : this(zone.id, zone.name, zone.type)
+}

--- a/tado-exporter/src/test/kotlin/click/dobel/tado/exporter/metrics/HomeModelRefresherTest.kt
+++ b/tado-exporter/src/test/kotlin/click/dobel/tado/exporter/metrics/HomeModelRefresherTest.kt
@@ -2,6 +2,7 @@ package click.dobel.tado.exporter.metrics
 
 import click.dobel.tado.api.UserHomes
 import click.dobel.tado.exporter.apiclient.TadoApiClient
+import click.dobel.tado.exporter.apiclient.model.toEntrySet
 import io.kotest.core.spec.style.StringSpec
 import io.mockk.every
 import io.mockk.just
@@ -35,7 +36,7 @@ internal class HomeModelRefresherTest : StringSpec({
       client.me()
       factory.createHomeMeters(me.homes.first())
       client.zones(homeId)
-      factory.createZoneMeters(me.homes.first(), initialZones.toSet())
+      factory.createZoneMeters(me.homes.first(), initialZones.toEntrySet())
     }
   }
 
@@ -63,9 +64,9 @@ internal class HomeModelRefresherTest : StringSpec({
       client.me()
       factory.createHomeMeters(me.homes.first())
       client.zones(homeId)
-      factory.createZoneMeters(me.homes.first(), initialZones.toSet())
+      factory.createZoneMeters(me.homes.first(), initialZones.toEntrySet())
       client.zones(homeId)
-      factory.createZoneMeters(me.homes.first(), setOf(bedRoom))
+      factory.createZoneMeters(me.homes.first(), setOf(ZoneEntry(bedRoom)))
     }
   }
 })

--- a/tado-exporter/src/test/kotlin/click/dobel/tado/exporter/metrics/TadoMeterFactoryTest.kt
+++ b/tado-exporter/src/test/kotlin/click/dobel/tado/exporter/metrics/TadoMeterFactoryTest.kt
@@ -23,7 +23,7 @@ class TadoMeterFactoryTest : StringSpec({
 
   "zoneTags creates Tags for home Id and zone Id" {
     val home = me.homes.first()
-    val zone = livingRoom
+    val zone = ZoneEntry(livingRoom)
     zoneTags(home, zone).toList() shouldContainExactlyInAnyOrder Tags.of(
       TadoMeterFactory.TAG_HOME_ID, home.id.toString(),
       TadoMeterFactory.TAG_ZONE_ID, zone.id.toString(),
@@ -55,7 +55,7 @@ class TadoMeterFactoryTest : StringSpec({
 
     val factory = TadoMeterFactory(meterRegistry, tadoApiClient)
     val home = me.homes.first()
-    val zone = livingRoom
+    val zone = ZoneEntry(livingRoom)
 
     factory.createZoneMeters(home, listOf(zone))
 
@@ -77,7 +77,7 @@ class TadoMeterFactoryTest : StringSpec({
 
     val factory = TadoMeterFactory(meterRegistry, tadoApiClient)
     val home = me.homes.first()
-    val zone = bedRoom
+    val zone = ZoneEntry(bedRoom)
 
     factory.createZoneMeters(home, listOf(zone))
 
@@ -98,7 +98,7 @@ class TadoMeterFactoryTest : StringSpec({
 
     val factory = TadoMeterFactory(meterRegistry, tadoApiClient)
     val home = me.homes.first()
-    val zone = hotWaterZone
+    val zone = ZoneEntry(hotWaterZone)
 
     factory.createZoneMeters(home, listOf(zone))
 


### PR DESCRIPTION
The Zone object contains devices with their state. When battery state changes, this leads to differences when comparing the Zone -- effectively letting the zone fall out of the registered meters.

This creates a specific "ZoneEntry" model object, containing only the identifying properties of a zone (Id, Name, Type), that also result in creating new meters when one of the value changes.