### PR TITLE
Feature: authentication ratelimit

### DIFF
--- a/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/TadoExporterConfiguration.kt
+++ b/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/TadoExporterConfiguration.kt
@@ -11,7 +11,9 @@ import click.dobel.tado.exporter.metrics.TadoMeterFactory
 import click.dobel.tado.exporter.metrics.ValueFilteringPrometheusRegistry
 import click.dobel.tado.util.aop.CallLoggingInterceptor
 import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.stats.StatsCounter
 import io.micrometer.core.instrument.Meter
+import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.config.MeterFilter
 import io.micrometer.core.instrument.config.MeterFilterReply
 import io.prometheus.metrics.model.registry.PrometheusRegistry
@@ -44,12 +46,13 @@ class TadoExporterConfiguration {
 
   fun cacheNames(): Array<String> = API_CLASSES.map { it.simpleName!! }.toTypedArray()
 
-  // cache is only used to cache shelly http responses during a single metrics call
+  // cache is only used to cache tado http responses during a single metrics call
   // any reasonably short value (shorter than scrape interval) will so
   @Bean
-  fun caffeineConfig(): Caffeine<Any, Any> =
+  fun caffeineConfig(meterRegistry: MeterRegistry): Caffeine<Any, Any> =
     Caffeine
       .newBuilder()
+      .recordStats { StatsCounter.disabledStatsCounter() }
       .expireAfterWrite(10, TimeUnit.SECONDS)
 
   @Bean

--- a/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/TadoExporterConfiguration.kt
+++ b/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/TadoExporterConfiguration.kt
@@ -9,6 +9,8 @@ import click.dobel.tado.api.ZoneState
 import click.dobel.tado.exporter.apiclient.TadoConfigurationProperties
 import click.dobel.tado.exporter.metrics.TadoMeterFactory
 import click.dobel.tado.exporter.metrics.ValueFilteringPrometheusRegistry
+import click.dobel.tado.exporter.ratelimit.OncePerIntervalRateLimiter
+import click.dobel.tado.exporter.ratelimit.RateLimiter
 import click.dobel.tado.util.aop.CallLoggingInterceptor
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.stats.StatsCounter
@@ -25,6 +27,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.minutes
 
 @Configuration
 @EnableCaching
@@ -74,6 +77,12 @@ class TadoExporterConfiguration {
       }
     }
   }
+
+  @Bean
+  fun authRateLimiter(): RateLimiter = OncePerIntervalRateLimiter(
+    "Authentication attempt",
+    1.minutes
+  )
 
   @Bean
   fun aopLogger() = CallLoggingInterceptor()

--- a/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/apiclient/auth/RateLimitException.kt
+++ b/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/apiclient/auth/RateLimitException.kt
@@ -1,0 +1,6 @@
+package click.dobel.tado.exporter.apiclient.auth
+
+class RateLimitException(
+  message: String,
+  cause: Throwable? = null
+) : Exception(message, cause)

--- a/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/apiclient/auth/TadoAuthFilter.kt
+++ b/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/apiclient/auth/TadoAuthFilter.kt
@@ -42,7 +42,6 @@ class TadoAuthFilter(
   private fun getAccessToken(): String {
     val auth = lastAuthResponse.get()
 
-    // TODO: how to synchronize parallel requests properly in Rx
     return when {
       auth == null -> newAuth()
         .run { updateLastAuthResponse(this) }

--- a/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/apiclient/auth/TadoAuthFilter.kt
+++ b/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/apiclient/auth/TadoAuthFilter.kt
@@ -36,6 +36,7 @@ class TadoAuthFilter(
 
   private fun updateLastAuthResponse(response: TadoAuthResponse): String {
     lastAuthResponse.set(response)
+    logger.info { "New bearer token obtained, expires in ${response.expiresIn} seconds, at ${response.expiresAt}." }
     return response.accessToken
   }
 

--- a/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/ratelimit/OncePerIntervalRateLimiter.kt
+++ b/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/ratelimit/OncePerIntervalRateLimiter.kt
@@ -1,0 +1,36 @@
+package click.dobel.tado.exporter.ratelimit
+
+import click.dobel.tado.exporter.apiclient.auth.RateLimitException
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+class OncePerIntervalRateLimiter(
+  private val usecase: String,
+  interval: Duration,
+  private val clock: Clock = Clock.systemUTC()
+) : RateLimiter {
+  private val interval = interval.toJavaDuration()
+  private val lastExecution = AtomicReference(Instant.MIN)
+
+  override fun <T> executeRateLimited(block: () -> T): T {
+    checkRateLimit()
+    return try {
+      block()
+    } finally {
+      updateLastExecution()
+    }
+  }
+
+  private fun checkRateLimit() {
+    val noAuthAttemptBefore = lastExecution.get().plus(interval)
+    if (now().isBefore(noAuthAttemptBefore))
+      throw RateLimitException("$usecase rate limit of 1/${interval.toSeconds()}s exceeded.")
+  }
+
+  private fun updateLastExecution() = lastExecution.set(now())
+
+  private fun now() = Instant.now(clock)
+}

--- a/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/ratelimit/RateLimiter.kt
+++ b/tado-exporter/src/main/kotlin/click/dobel/tado/exporter/ratelimit/RateLimiter.kt
@@ -1,0 +1,5 @@
+package click.dobel.tado.exporter.ratelimit
+
+interface RateLimiter {
+  fun <T> executeRateLimited(block: () -> T): T
+}

--- a/tado-exporter/src/test/kotlin/click/dobel/tado/exporter/apiclient/TadoApiClientIT.kt
+++ b/tado-exporter/src/test/kotlin/click/dobel/tado/exporter/apiclient/TadoApiClientIT.kt
@@ -1,6 +1,5 @@
-package click.dobel.tado.exporter.client
+package click.dobel.tado.exporter.apiclient
 
-import click.dobel.tado.exporter.apiclient.TadoApiClient
 import click.dobel.tado.exporter.test.ApiMockMappings
 import click.dobel.tado.exporter.test.AuthMockMappings
 import click.dobel.tado.exporter.test.IntegrationTest

--- a/tado-exporter/src/test/kotlin/click/dobel/tado/exporter/apiclient/auth/TadoAuthFilterTest.kt
+++ b/tado-exporter/src/test/kotlin/click/dobel/tado/exporter/apiclient/auth/TadoAuthFilterTest.kt
@@ -1,7 +1,5 @@
-package click.dobel.tado.exporter.client.auth
+package click.dobel.tado.exporter.apiclient.auth
 
-import click.dobel.tado.exporter.apiclient.auth.AuthClient
-import click.dobel.tado.exporter.apiclient.auth.TadoAuthFilter
 import click.dobel.tado.exporter.apiclient.auth.model.request.TadoAuthLoginRequest
 import click.dobel.tado.exporter.apiclient.auth.model.request.TadoAuthRefreshRequest
 import click.dobel.tado.exporter.apiclient.auth.model.response.TadoAuthResponse

--- a/tado-exporter/src/test/kotlin/click/dobel/tado/exporter/ratelimit/OncePerIntervalRateLimiterTest.kt
+++ b/tado-exporter/src/test/kotlin/click/dobel/tado/exporter/ratelimit/OncePerIntervalRateLimiterTest.kt
@@ -1,0 +1,68 @@
+package click.dobel.tado.exporter.ratelimit
+
+import click.dobel.tado.exporter.apiclient.auth.RateLimitException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Instant
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
+
+class OncePerIntervalRateLimiterTest : FreeSpec({
+
+  val clock = mockk<Clock>()
+
+  lateinit var testTime: Instant
+  lateinit var rateLimiter: OncePerIntervalRateLimiter
+
+  val interval = 1.minutes
+
+  fun execute(): Boolean = true
+  fun throwing(): Boolean = error("test")
+
+  beforeEach {
+    testTime = Instant.now()
+    every { clock.instant() } answers { testTime }
+
+    rateLimiter = OncePerIntervalRateLimiter("Test", interval, clock)
+  }
+
+  "should allow execution once" {
+    rateLimiter.executeRateLimited { execute() } shouldBe true
+  }
+
+  "should disallow second execution within the interval" {
+    rateLimiter.executeRateLimited { execute() } shouldBe true
+    shouldThrow<RateLimitException> { rateLimiter.executeRateLimited { execute() } }
+  }
+
+  "should disallow further executions within the interval" {
+    rateLimiter.executeRateLimited { execute() } shouldBe true
+    shouldThrow<RateLimitException> { rateLimiter.executeRateLimited { execute() } }
+    shouldThrow<RateLimitException> { rateLimiter.executeRateLimited { execute() } }
+  }
+
+  "should disallow second execution close within the interval" {
+    rateLimiter.executeRateLimited { execute() } shouldBe true
+
+    testTime += interval.toJavaDuration().minusMillis(1)
+
+    shouldThrow<RateLimitException> { rateLimiter.executeRateLimited { execute() } }
+  }
+
+  "should count throwing executions" {
+    shouldThrow<IllegalStateException> { rateLimiter.executeRateLimited { throwing() } }
+    shouldThrow<RateLimitException> { rateLimiter.executeRateLimited { throwing() } }
+  }
+
+  "should allow second execution exactly after the interval" {
+    rateLimiter.executeRateLimited { execute() } shouldBe true
+
+    testTime += interval.toJavaDuration()
+
+    rateLimiter.executeRateLimited { execute() } shouldBe true
+  }
+})


### PR DESCRIPTION
Should anything go wrong during authentication, there was no limit in trying to obtain a token, potentially flooding the authentication server. This PR introduces a rate limit of 1 attempt per minute on the authentication endpoint. 